### PR TITLE
Added files for providers strip and page

### DIFF
--- a/source/providers/index.md
+++ b/source/providers/index.md
@@ -1,0 +1,7 @@
+---
+title: providers
+date: 2020-02-26 15:58:24
+layout:
+type: providers
+excerpt:
+---

--- a/themes/custom/layout/_partial/about.ejs
+++ b/themes/custom/layout/_partial/about.ejs
@@ -1,4 +1,5 @@
 <div class="about">
-    <%- partial('_partial/insurance-strip') %>
+    <%- partial('_partial/providers-strip') %>
     <%- partial('_partial/news-strip') %>
+    <%- partial('_partial/testimonials-strip') %>
 </div>

--- a/themes/custom/layout/_partial/providers-strip.ejs
+++ b/themes/custom/layout/_partial/providers-strip.ejs
@@ -1,0 +1,19 @@
+<div class="component-post providers-strip">
+    <!-- Display content from the News Comopnent Post -->
+    <% let posts = site.posts %>
+    <% posts.forEach(function(item) { %>
+        <% if (item.title === 'Providers & Staff') { %>
+            <h2 class='component-title'><%- item.title %></h2>
+            <%- item.content %>
+        <% } %>
+    <% }) %>
+    <!-- Link to the Providers Page / index.md-->
+    <div class="button-wrapper">
+        <% let pages = site.pages %>
+        <% pages.forEach(function(item) { %>
+            <% if (item.type === 'providers') { %>
+                <a href="<% config.root %>/providers" class='button'>Go to Providers Page</a>
+            <% } %>
+        <% }) %>
+    </div>
+</div>


### PR DESCRIPTION
- Site files now have providers.ejs which pulls in title and content from a component post with title "Providers & Staff" (which has been added from Netlify CMS)
- providers page was added as well so the providers strip can link to the entire page of staff and whatnot