### PR TITLE
Tech now configured for page creation and deletion from CMS UI

### DIFF
--- a/source/about/index.md
+++ b/source/about/index.md
@@ -4,6 +4,6 @@ date: 2020-01-31 12:35:54
 layout: about
 type: top-level
 menulabel: About
-children: false
+children: true
 ---
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam tempor mattis mauris, sit amet tincidunt nisl euismod ut. Duis semper sed sem sed posuere. Maecenas et vulputate tortor. Aenean tempus magna libero, non eleifend lectus fermentum eget. Praesent efficitur sapien vitae viverra laoreet. Quisque a pharetra dui, nec lacinia tortor. Donec quis cursus dolor, eget facilisis turpis. Aenean egestas id enim sit amet volutpat. Aliquam eu diam lectus. Quisque varius lorem lorem. Donec dui eros, auctor a tincidunt ac, elementum non turpis. Curabitur porta vel dolor nec semper.

--- a/source/about/news/index.md
+++ b/source/about/news/index.md
@@ -3,5 +3,8 @@ title: News
 date: 2020-02-07 10:51:19
 layout: blog
 type: lower-level
+children: false
+parent: About
+menulabel: News
 ---
 Welcome to our news page. Stay up to date on the latest news from our center and from the neurpsychiatric industry, including TMS therapy and HBOT advancements, and more!

--- a/source/about/providers/index.md
+++ b/source/about/providers/index.md
@@ -3,5 +3,8 @@ title: Providers & Staff
 date: 2020-02-26 15:58:24
 layout:
 type: lower-level
+children: false
+parent: About
+menulabel: Providers
 ---
 Meet our talented team of providers and staff!

--- a/source/admin/config.yml
+++ b/source/admin/config.yml
@@ -40,40 +40,7 @@ collections:
       - {label: "Featured Image", name: "thumbnail", widget: "image", required: false}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "top-level-pages"
-    label: "Top-Level Pages"
-    files:
-      - label: "Services Page"
-        name: "services"
-        file: "source/services/index.md"
-        fields:
-          - {label: Title, name: title, widget: string}
-          - {label: "Body", name: "body", widget: "markdown"}
-      - label: "Conditions Treated Page"
-        name: "conditions"
-        file: "source/conditions/index.md"
-        fields:
-          - {label: Title, name: title, widget: string}
-          - {label: "Body", name: "body", widget: "markdown"}
-      - label: "Services Page"
-        name: "services"
-        file: "source/services/index.md"
-        fields:
-          - {label: Title, name: title, widget: string}
-          - {label: "Body", name: "body", widget: "markdown"}
-      - label: "About Page"
-        name: "about"
-        file: "source/about/index.md"
-        fields:
-          - {label: Title, name: title, widget: string}
-          - {label: "Body", name: "body", widget: "markdown"} 
-      - label: "Contact Page"
-        name: "contact"
-        file: "source/contact/index.md"
-        fields:
-          - {label: Title, name: title, widget: string}
-          - {label: "Body", name: "body", widget: "markdown"}
-  - name: "pages" # Used in routes, e.g., /admin/collections/blog
-    label: "Pages" # Used in the UI
+    label: "Top Level Pages" # Used in the UI
     folder: "source/" # The path to the folder where the documents are stored
     create: true # Allow users to create new documents in this collection
     slug: "index" # Filename template, e.g., YYYY-MM-DD-title.md
@@ -81,6 +48,22 @@ collections:
     fields: # The fields for each document, usually in front matter
       - {label: "Draft", name: "draft", widget: "boolean", default: true}
       - {label: "Type", name: "type", widget: "hidden", default: "top-level"}
+      - {label: "Child Pages", name: "children", widget: "boolean", default: "false"}
+      - {label: "Menu Label", name: "menulabel", widget: "string"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "lower-level-pages" # Used in routes, e.g., /admin/collections/blog
+    label: "Lower Level Pages" # Used in the UI
+    folder: "source/" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    slug: "index" # Filename template, e.g., YYYY-MM-DD-title.md
+    path: '{{title}}/{{slug}}'
+    fields: # The fields for each document, usually in front matter
+      - {label: "Draft", name: "draft", widget: "boolean", default: true}
+      - {label: "Type", name: "type", widget: "hidden", default: "lower-level"}
+      - {label: "Child Pages", name: "children", widget: "hidden", default: "false"}
+      - {label: "Parent Page Name", name: "parent", widget: "string"}
+      - {label: "Menu Label", name: "menulabel", widget: "string"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "site-configuration"

--- a/source/conditions/anxiety/index.md
+++ b/source/conditions/anxiety/index.md
@@ -3,4 +3,7 @@ title: Anxiety
 date: 2020-02-27 13:54:16
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: Anxiety
 ---

--- a/source/conditions/bipolar/index.md
+++ b/source/conditions/bipolar/index.md
@@ -3,4 +3,7 @@ title: Bipolar Disorders
 date: 2020-02-27 13:54:34
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: Bipolar
 ---

--- a/source/conditions/chronic-pain/index.md
+++ b/source/conditions/chronic-pain/index.md
@@ -3,4 +3,7 @@ title: Chronic Pain
 date: 2020-02-27 13:55:20
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: Chronic Pain
 ---

--- a/source/conditions/depression/index.md
+++ b/source/conditions/depression/index.md
@@ -3,4 +3,7 @@ title: Depression
 date: 2020-02-27 13:54:12
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: Depression
 ---

--- a/source/conditions/ocd/index.md
+++ b/source/conditions/ocd/index.md
@@ -3,4 +3,7 @@ title: Obessive-Compulsive Disorder (OCD)
 date: 2020-02-27 13:54:29
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: OCD
 ---

--- a/source/conditions/post-stroke/index.md
+++ b/source/conditions/post-stroke/index.md
@@ -3,4 +3,7 @@ title: Post-Stroke Recovery
 date: 2020-02-27 13:55:11
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: Post-Stroke
 ---

--- a/source/conditions/ptsd/index.md
+++ b/source/conditions/ptsd/index.md
@@ -3,4 +3,7 @@ title: Post Traumatic Stress Disorder (PTSD)
 date: 2020-02-27 13:54:24
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: PTSD
 ---

--- a/source/conditions/tinnitus/index.md
+++ b/source/conditions/tinnitus/index.md
@@ -3,4 +3,7 @@ title: Tinnitus
 date: 2020-02-27 13:55:30
 layout:
 type: lower-level
+children: false
+parent: Treated Conditions
+menulabel: Tinnitus
 ---

--- a/source/services/advanced-diagnostics/index.md
+++ b/source/services/advanced-diagnostics/index.md
@@ -3,4 +3,7 @@ title: Advanced Diagnostics
 date: 2020-02-27 13:51:24
 layout:
 type: lower-level
+children: false
+parent: Services
+menulabel: Diagnostics
 ---

--- a/source/services/hbot/index.md
+++ b/source/services/hbot/index.md
@@ -3,4 +3,7 @@ title: Hyperbaric Oxygen Therapy (HBOT)
 date: 2020-02-27 13:51:12
 layout:
 type: lower-level
+children: false
+parent: Services
+menulabel: HBOT
 ---

--- a/source/services/tms-therapy/index.md
+++ b/source/services/tms-therapy/index.md
@@ -3,4 +3,7 @@ title: Transcranial Magnetic Stimulation (TMS)
 date: 2020-02-27 13:50:47
 layout:
 type: lower-level
+children: false
+parent: Services
+menulabel: TMS Therapy
 ---

--- a/themes/custom/layout/_partial/nav.ejs
+++ b/themes/custom/layout/_partial/nav.ejs
@@ -19,55 +19,27 @@
                 <div class="menu-link-wrapper">
                     <a class='nav-link' href='<%- config.root %>'>Home</a>
                 </div>
+                <!-- Loop through all pages -->
                 <% for (let i = 0; i < site.pages.data.length; i++) { %>
                     <% let thisPage = site.pages.data %>
+                    <!-- Print top level pages -->
                     <% if (thisPage[i].type === 'top-level') { %>
                         <div class="menu-link-wrapper">
+                            <!-- If the top-level page has child pages, give it a dropdown icon -->
                             <% if (thisPage[i].children === true) { %>
                                 <a class='nav-link' href='<%- config.root %><%- thisPage[i].path %>'><%- thisPage[i].menulabel %><i class="fas fa-angle-down"></i></a>
+                                <div class="dropdown">
                                 <!-- If there's childern pages, loop through all children and pick the ones that have parent = this page's title --> 
-                                <% if (thisPage[i].type === 'lower-level') { %>
-                                    <%- console.log(thisPage[i].title) %>
-                                    <%- console.log(url_for(thisPage[i])) %>
-                                <% } %>
+                                    <% for (let j = 0; j < site.pages.data.length; j++) { %>
+                                        <% if ((thisPage[j].type === 'lower-level') && (thisPage[j].parent === thisPage[i].menulabel)) { %>
+                                            <a class='nav-link' href='<%- config.root %><%- thisPage[j].path %>'><%- thisPage[j].menulabel %></a>
+                                        <% } %>
+                                    <% } %>
+                                </div>
                             <% } else { %>
                                 <a class='nav-link' href='<%- config.root %><%- thisPage[i].path %>'><%- thisPage[i].menulabel %></a>
                             <% } %>
                         </div>
-                    <% } %>
-                <% } %>
-                <!-- Pull each menu item in from the local _config.yml file -->
-                <% for (var i in theme.menu) { %>
-                     <!-- If it's the services menu link, render that link + submenu links -->
-                     <% if (i === 'Services') { %>
-                        <div class="menu-link-wrapper">
-                            <a class='nav-link' href='<%- url_for(theme.menu[i]) %>'><%- i %><i class="fas fa-angle-down"></i></a>
-                            <div class="dropdown">
-                                <% for (var j in theme.services) { %>
-                                    <a class='nav-link' href='<%- url_for(theme.services[j]) %>'><%- j %></a>
-                                <% } %> 
-                            </div>
-                        </div>
-                    <% } else if (i === 'Treated Conditions') { %>
-                        <div class="menu-link-wrapper">
-                            <a class='nav-link' href='<%- url_for(theme.menu[i]) %>'><%- i %><i class="fas fa-angle-down"></i></a>
-                            <div class="dropdown">
-                                <% for (var j in theme.conditions) { %>
-                                    <a class='nav-link' href='<%- url_for(theme.conditions[j]) %>'><%- j %></a>
-                                <% } %> 
-                            </div>
-                        </div>
-                    <% } else if (i === 'About') { %>
-                        <div class="menu-link-wrapper">
-                            <a class='nav-link' href='<%- url_for(theme.menu[i]) %>'><%- i %><i class="fas fa-angle-down"></i></a>
-                            <div class="dropdown">
-                                <% for (var j in theme.about) { %>
-                                    <a class='nav-link' href='<%- url_for(theme.about[j]) %>'><%- j %></a>
-                                <% } %> 
-                            </div>
-                        </div>
-                    <% } else { %>
-                        <a class='nav-link' href='<%- url_for(theme.menu[i]) %>'><%- i %></a>
                     <% } %>
                 <% } %>
             </div>


### PR DESCRIPTION
- Nav menu now programmed to be way smarter! 
- It now takes page information from the site data vs. the config.yml file in Hexo, which allows Netlify CMS to be configured to speak its language.

Two collections added to the CMS UI: 
- Top Level Pages: has new 'children' boolean field, which will slap a dropdown icon in if true, and will loop through to find children pages that have a 'parent' field set to this page
- Lower Level Pages : has new 'parent' string field, which will be used to link this child page to its parent in the navigation
- Both pages also now use 'menulabel' fields, which determine what their name will be in the rendered navigation menu. This allows you to change the title of the page that is rendered to that page, without affecting its place in the page tree. 